### PR TITLE
Fixed Spelunking Chances

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/effects/effects/EffectSpelunking.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/effects/effects/EffectSpelunking.kt
@@ -62,8 +62,12 @@ class EffectSpelunking : Effect(
 
         val multiplier = getMultiplier(level)
 
-        if (multiplier >= 2) {
-            for (i in 2..multiplier) {
+        if (multiplier == 1) {
+            return
+        }
+
+        if (multiplier > 2) {
+            for (i in 2 until multiplier) {
                 DropQueue(player)
                     .addItems(*event.items.map { item -> item.itemStack })
                     .push()


### PR DESCRIPTION
- Made it so that if you have a `multiplier` of 1x you only get 1 block
- Fixed a case where if you had a `multiplier` >= 2 then you would always get `multiplier` blocks with whatever your current chance is at another. (i.e 4% of 3x drops giving you 3x drops with a 4% at 4x)