### PR TITLE
Fix gui title

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/SkillLevelGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/SkillLevelGUI.kt
@@ -33,7 +33,7 @@ class SkillLevelGUI(
             ItemFlag.HIDE_ATTRIBUTES
         ).setDisplayName(
             plugin.configYml.getFormattedString("gui.skill-icon.name")
-                .replace("%skill%", skill.levelName)
+                .replace("%skill%", skill.name)
                 .replace(
                     "%level%",
                     player.getSkillLevel(skill).toString()
@@ -140,7 +140,7 @@ class SkillLevelGUI(
         val pageKey = "page"
 
         levels = menu(plugin.configYml.getInt("level-gui.rows")) {
-            setTitle(skill.name)
+            setTitle(skill.levelName)
             setMask(
                 FillerMask(
                     maskItems,


### PR DESCRIPTION
Fixed the title of the gui using skill.name instead of skill.levelName essentially fixing resource packs where the name of the gui-name change is a requirement.