### PR TITLE
Fixed exploration skill disable

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/skills/SkillExploration.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/skills/SkillExploration.kt
@@ -46,12 +46,8 @@ class SkillExploration : Skill(
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     fun handleLevelling(event: EntityDamageEvent) {
-    
-        val player = event.entity
-
-        if (player !is Player) {
-            return
-        }
+        val player = (event.entity as? Player)?.filterSkillEnabled() ?: return
+        
         if (this.config.getStrings("disabled-in-worlds").containsIgnoreCase(player.getWorld().getName())) {
             return
         }


### PR DESCRIPTION
Before even if the skill was disabled the player was gaining XP from falling, now it's fixed.