### PR TITLE
Fix: Recount message color-syntax discrepancy

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/commands/CommandRecount.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/commands/CommandRecount.kt
@@ -48,7 +48,7 @@ class CommandRecount(plugin: EcoPlugin): Subcommand(
                 sender.sendMessage(
                     plugin.langYml.getMessage("recounted-player")
                         .replace("%player%", player.displayName)
-                        .replace("%effect%", "&6ALL")
+                        .replace("%effect%", "ALL")
                         .replace("%level%", total.toString())
                 )
             } else {


### PR DESCRIPTION
Long-standing discrepancy in which color-formatting syntax is incorrectly used in output messages