### PR TITLE
Add progress bar and level placeholders to action bar

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/SkillDisplayListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/SkillDisplayListener.kt
@@ -18,6 +18,8 @@ import org.bukkit.boss.BarStyle
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
+import kotlin.math.ceil
+import kotlin.math.floor
 
 class SkillDisplayListener(
     private val plugin: EcoPlugin
@@ -43,6 +45,11 @@ class SkillDisplayListener(
                     nextLevelMessage
                 )
                 string = string.replace("%gained_xp%", NumberUtils.format(amount))
+                val percentage = player.getSkillProgress(skill) / nextLevel * 100
+                val percentageMessage = "§a▬".repeat(floor(percentage/10).toInt()) + "§7▬".repeat(ceil((100-percentage)/10).toInt())
+                string = string.replace("%progress_bar%", percentageMessage)
+                val level = player.getSkillLevel(skill)
+                string = string.replace("%level%", level.toString())
                 ActionBarUtils.blacklist(player.uniqueId)
                 player.spigot().sendMessage(
                     ChatMessageType.ACTION_BAR,


### PR DESCRIPTION
I've added the placeholder **%progress_bar%** and **%level%** of certain skill to the action-bar string. 

![image](https://user-images.githubusercontent.com/42357900/208313292-30c3f782-4308-47b3-8bf0-511aa6ef5791.png)

```
action-bar:
      format: '&f%skill% %level% &8| &3%current_xp% %progress_bar% &3%required_xp% &8| &e+%gained_xp%'
```