### PR TITLE
Fix: Easy exploration skill xp gain from falling

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/skills/SkillExploration.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/skills/SkillExploration.kt
@@ -10,6 +10,9 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.player.PlayerMoveEvent
+import kotlin.math.abs
+import kotlin.math.pow
+import kotlin.math.sqrt
 
 class SkillExploration : Skill(
     "exploration"
@@ -30,6 +33,11 @@ class SkillExploration : Skill(
         }
 
         if (from.distance(to) > 100) {
+            return
+        }
+
+        // If distance travelled on the Y axis is larger than distance travelled on X and Z, consider it a falling player, and dismiss
+        if (abs(from.blockY - to.blockY) > sqrt((from.x - to.x).pow(2) + (from.z - to.z).pow(2))) {
             return
         }
 


### PR DESCRIPTION
If you fly up with an elytra to a high altitude and then fall down, you can easily level-up the exploration skill. My fix creates a check that makes sure that the distance traveled on the X and Z axis is larger than the Y axis. That should fix the issue.