### PR TITLE
Fix infinite armory xp on player /kill

### DIFF
--- a/eco-core/core-plugin/src/main/resources/skills/armory.yml
+++ b/eco-core/core-plugin/src/main/resources/skills/armory.yml
@@ -118,6 +118,10 @@ reward-messages:
 xp-gain-methods:
   - trigger: take_damage
     multiplier: 1.44
+    filters:
+      not_damage_cause:
+        - KILL
+        - SUICIDE
 
 # Conditions that must be met to gain XP. While you can add conditions to xp
 # gain methods, if you have many this can be annoying, so this is global.


### PR DESCRIPTION
I noticed this when messing around with the plugin on my server. When a player was `/kill`ed, or ran `/suicide` themselves, they would gain infinite armory XP. I assume most server owners would not want this behavior. Adding these two lines seemed to work for me, but I'm not sure if it's a complete fix.