### PR TITLE
Disable damage indicator for certain entities

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/DamageIndicatorListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/DamageIndicatorListener.kt
@@ -3,6 +3,7 @@ package com.willfp.ecoskills.skills.display
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.core.Prerequisite
 import com.willfp.eco.core.integrations.hologram.HologramManager
+import com.willfp.eco.util.containsIgnoreCase
 import com.willfp.eco.util.formatEco
 import com.willfp.eco.util.randDouble
 import com.willfp.eco.util.toNiceString
@@ -37,6 +38,13 @@ class DamageIndicatorListener(
         }
 
         if (victim is Player && victim.isBlocking) {
+            return
+        }
+
+        val disabledForEntities = plugin.configYml
+            .getStrings("damage-indicators.disabled-for-entities")
+
+        if (disabledForEntities.containsIgnoreCase(victim.type.name)) {
             return
         }
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -272,6 +272,52 @@ damage-indicators:
   enabled: true
   final-damage: false # If final damage (with reductions applied) should be used.
 
+  disabled-for-entities:
+    - area_effect_cloud
+    - armor_stand
+    - arrow
+    - block_display
+    - dragon_fireball
+    - dropped_item
+    - egg
+    - ender_crystal
+    - ender_pearl
+    - ender_signal
+    - evoker_fangs
+    - experience_orb
+    - fireball
+    - falling_block
+    - firework_rocket
+    - fishing_hook
+    - glow_item_frame
+    - interaction
+    - item_display
+    - item_frame
+    - leash_hitch
+    - lightning
+    - llama_spit
+    - marker
+    - minecart
+    - minecart_chest
+    - minecart_command
+    - minecart_furnace
+    - minecart_hopper
+    - minecart_mob_spawner
+    - minecart_tnt
+    - painting
+    - primed_tnt
+    - shulker_bullet
+    - small_fireball
+    - snowball
+    - spectral_arrow
+    - splash_potion
+    - text_display
+    - thrown_exp_bottle
+    - trident
+    - unknown
+    - wind_charge
+    - wither_skull
+
   format:
     normal: "&7%damage%"
     crit: "&f✧ <gradient:#f953c6>%damage%</gradient:#b91d73> &f✧"


### PR DESCRIPTION
I've exploded like thousands of stacks of items on ground with TNT and the server created thousands of damage indicators. It's kind of a lag issue, because items can be created very fast. I've also included some entities that probably should not have a damage indicator.

https://media.discordapp.net/attachments/1207681935527378974/1214602885992816742/image.png?ex=65f9b616&is=65e74116&hm=d1cd38c9188661b2b40aac63821f5e2f9339cf9068f09e4dc398ba27517f5b8d&=&format=webp&quality=lossless