### PR TITLE
Require Pumpkins & Melons to not be player placed

### DIFF
--- a/eco-core/core-plugin/src/main/resources/skills/farming.yml
+++ b/eco-core/core-plugin/src/main/resources/skills/farming.yml
@@ -147,15 +147,15 @@ xp-gain-methods:
       blocks:
         - wheat
         - carrots
-        - melon
         - nether_wart
 
   - trigger: mine_block
     multiplier: 4.5
     filters:
-      fully_grown: true
+      player_placed: false
       blocks:
         - pumpkin
+        - melon
 
   - trigger: mine_block
     multiplier: 5


### PR DESCRIPTION
With the current default configuration, players can repeatedly place and break a pumpkin (or a melon with silk touch) and get farming XP each time. This fixes that by requiring pumpkins and melons to *not* be player placed.

I also moved melon to the same category as pumpkin; given that they require the same effort to grow, it makes sense that they give the same XP. Melons and pumpkins don't have growth stages either (their stems do), so `fully_grown` isn't necessary. It also means less config lines!

As a side note, I noticed the default configuration doesn't actually give XP for glow berries, cactuses, or sugar cane, despite them being in the config because they don't have growth stages. This is something you probably want to address by having a trigger for picking berries and for breaking cactuses/sugar cane (e.g. breaking a 3 high sugar cane at the bottom gives XP for each block).

Thanks!