### PR TITLE
Fix 2 issues

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/commands/CommandTop.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/commands/CommandTop.kt
@@ -36,7 +36,7 @@ class CommandTop(plugin: EcoPlugin) :
             }
 
             val start = (page - 1) * 10 + 1
-            val end = start + 9 + (page - 1)
+            val end = start + 9
             val positions = (start..end).toList()
 
             val top = if (skill == null) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/commands/CommandTop.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/commands/CommandTop.kt
@@ -35,9 +35,9 @@ class CommandTop(plugin: EcoPlugin) :
                 return@runAsync
             }
 
-            val offset = (page - 1) * 10
-
-            val positions = ((offset + page)..(offset + page + 9)).toList()
+            val start = (page - 1) * 10 + 1
+            val end = start + 9 + (page - 1)
+            val positions = (start..end).toList()
 
             val top = if (skill == null) {
                 positions.mapNotNull { Skills.getTop(it) }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/GainXPDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/GainXPDisplay.kt
@@ -111,7 +111,7 @@ class GainXPDisplay(
         )
             .replace("%current_xp%", event.player.getSkillXP(event.skill).toNiceString())
             .replace("%required_xp%", event.player.getFormattedRequiredXP(event.skill))
-            .replace("%gained_xp%", gainCache.get(event.player.uniqueId) { event.skill.id to 0.0 }.toNiceString())
+            .replace("%gained_xp%", gainCache.get(event.player.uniqueId) { event.skill.id to 0.0 }.second.toNiceString())
             .formatEco(
                 placeholderContext(
                     event.player,

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/GainXPDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/GainXPDisplay.kt
@@ -18,13 +18,13 @@ import com.willfp.ecoskills.api.getFormattedRequiredXP
 import com.willfp.ecoskills.api.getSkillLevel
 import com.willfp.ecoskills.api.getSkillProgress
 import com.willfp.ecoskills.api.getSkillXP
-import com.willfp.ecoskills.skills.Skill
 import org.bukkit.boss.BarColor
 import org.bukkit.boss.BarStyle
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import java.time.Duration
+import java.util.UUID
 
 private val xpGainSoundEnabledKey = PersistentDataKey(
     namespacedKeyOf("ecoskills", "gain_sound_enabled"),
@@ -42,7 +42,7 @@ val Player.isXPGainSoundEnabled: Boolean
 class GainXPDisplay(
     private val plugin: EcoPlugin
 ) : Listener {
-    private val gainCache: Cache<Skill, Double> = Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(3))
+    private val gainCache: Cache<UUID, Pair<String, Double>> = Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(3))
         .build()
 
     private val sound = if (plugin.configYml.getBool("skills.gain-xp.sound.enabled")) {
@@ -54,8 +54,8 @@ class GainXPDisplay(
     @EventHandler
     fun handle(event: PlayerSkillXPGainEvent) {
         val player = event.player
-        val current = gainCache.get(event.skill) { 0.0 }
-        gainCache.put(event.skill, current + event.gainedXP)
+        val current = gainCache.get(player.uniqueId) { event.skill.id to 0.0 }
+        gainCache.put(player.uniqueId, event.skill.id to (current.second + event.gainedXP))
 
         // Run next tick because level up calls before xp is added
         plugin.scheduler.run {
@@ -111,7 +111,7 @@ class GainXPDisplay(
         )
             .replace("%current_xp%", event.player.getSkillXP(event.skill).toNiceString())
             .replace("%required_xp%", event.player.getFormattedRequiredXP(event.skill))
-            .replace("%gained_xp%", gainCache.get(event.skill) { 0.0 }.toNiceString())
+            .replace("%gained_xp%", gainCache.get(event.player.uniqueId) { event.skill.id to 0.0 }.toNiceString())
             .formatEco(
                 placeholderContext(
                     event.player,


### PR DESCRIPTION
- Fix print /top command. Leaderboard should be in range 1..10, 11..20, 21..30 to properly show players in list, before it was 1..10, 12..21 and etc.
- gainCache should be per player. We should show xp individually per player, not from all players.