### PR TITLE
Added "CONTACT" as a filtered option

### DIFF
--- a/eco-core/core-plugin/src/main/resources/skills/armory.yml
+++ b/eco-core/core-plugin/src/main/resources/skills/armory.yml
@@ -122,6 +122,7 @@ xp-gain-methods:
       not_damage_cause:
         - KILL
         - SUICIDE
+        - CONTACT
 
 # Conditions that must be met to gain XP. While you can add conditions to xp
 # gain methods, if you have many this can be annoying, so this is global.


### PR DESCRIPTION
Certain blocks give constant XP when the player gets in contact with them. Eg: Cactus. This should fix it.