### PR TITLE
Player leaderboard position placeholder

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/EcoSkillsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/EcoSkillsPlugin.kt
@@ -87,6 +87,7 @@ class EcoSkillsPlugin : LibreforgePlugin() {
 
         EcoSkillsTopPlaceholder(this).register()
         EcoSkillsSkillTopPlaceholder(this).register()
+        Skills.registerPlaceholders(this)
     }
 
     override fun handleReload() {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/Levellable.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/Levellable.kt
@@ -44,6 +44,12 @@ abstract class Levellable(
             }.map { it.uniqueId }
         }
 
+    fun getPosition(uuid: UUID): Int? {
+        val leaderboard = leaderboardCache.get(true)
+        val index = leaderboard.indexOf(uuid)
+        return if (index == -1) null else index + 1
+    }
+
     private val descCache = Caffeine.newBuilder()
         .expireAfterWrite(plugin.configYml.getInt("gui.cache-ttl").toLong(), TimeUnit.MILLISECONDS)
         .build<Int, String>()
@@ -73,6 +79,12 @@ abstract class Levellable(
 
         PlayerPlaceholder(plugin, "${id}_description") {
             getDescription(getActualLevel(it))
+        }.register()
+
+        PlayerPlaceholder(plugin, "top_position_${id}") { player ->
+            val emptyPosition = plugin.langYml.getString("top.empty-position")
+            val position = getPosition(player.uniqueId)
+            position?.toString() ?: emptyPosition
         }.register()
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/Levellable.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/Levellable.kt
@@ -81,7 +81,7 @@ abstract class Levellable(
             getDescription(getActualLevel(it))
         }.register()
 
-        PlayerPlaceholder(plugin, "top_position_${id}") { player ->
+        PlayerPlaceholder(plugin, "${id}_leaderboard_rank") { player ->
             val emptyPosition = plugin.langYml.getString("top.empty-position")
             val position = getPosition(player.uniqueId)
             position?.toString() ?: emptyPosition

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/EcoSkillsTopPlaceholder.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/EcoSkillsTopPlaceholder.kt
@@ -9,30 +9,26 @@ import java.util.regex.Pattern
 class EcoSkillsSkillTopPlaceholder(
     private val plugin: EcoPlugin
 ) : RegistrablePlaceholder {
-    private val pattern = Pattern.compile("(top_)[a-z]+_[0-9]+_[a-z]+")
+    private val pattern = Pattern.compile("top_([a-z0-9_]+)_(\\d+)_(name|level|amount)")
 
     override fun getPattern(): Pattern = pattern
     override fun getPlugin(): EcoPlugin = plugin
 
     override fun getValue(params: String, ctx: PlaceholderContext): String? {
-        val emptyposition: String = plugin.langYml.getString("top.empty-position")
-        val args = params.split("_")
+        val emptyPosition: String = plugin.langYml.getString("top.empty-position")
+        val matcher = pattern.matcher(params)
 
-        if (args.size < 3) {
-            return null
-        }
+        if (!matcher.matches()) return null
 
-        if (args[0] != "top") {
-            return null
-        }
+        val skillId = matcher.group(1) // Skill ID (allows underscores)
+        val place = matcher.group(2).toIntOrNull() ?: return null
+        val type = matcher.group(3)
 
-        val skill = Skills.getByID(args[1]) ?: return null
+        val skill = Skills.getByID(skillId) ?: return null
 
-        val place = args[2].toIntOrNull() ?: return null
-
-        return when (args.last()) {
-            "name" -> skill.getTop(place)?.player?.savedDisplayName ?: emptyposition
-            "level", "amount" -> skill.getTop(place)?.level?.toString() ?: emptyposition
+        return when (type) {
+            "name" -> skill.getTop(place)?.player?.savedDisplayName ?: emptyPosition
+            "level", "amount" -> skill.getTop(place)?.level?.toString() ?: emptyPosition
             else -> null
         }
     }
@@ -41,28 +37,23 @@ class EcoSkillsSkillTopPlaceholder(
 class EcoSkillsTopPlaceholder(
     private val plugin: EcoPlugin
 ) : RegistrablePlaceholder {
-    private val pattern = Pattern.compile("(top_)[0-9]+_[a-z]+")
+    private val pattern = Pattern.compile("top_(\\d+)_(name|level|amount)")
 
     override fun getPattern(): Pattern = pattern
     override fun getPlugin(): EcoPlugin = plugin
 
     override fun getValue(params: String, ctx: PlaceholderContext): String? {
-        val emptyposition: String = plugin.langYml.getString("top.empty-position")
-        val args = params.split("_")
+        val emptyPosition: String = plugin.langYml.getString("top.empty-position")
+        val matcher = pattern.matcher(params)
 
-        if (args.size < 2) {
-            return null
-        }
+        if (!matcher.matches()) return null
 
-        if (args[0] != "top") {
-            return null
-        }
+        val place = matcher.group(1).toIntOrNull() ?: return null
+        val type = matcher.group(2)
 
-        val place = args[1].toIntOrNull() ?: return null
-
-        return when (args.last()) {
-            "name" -> Skills.getTop(place)?.player?.savedDisplayName ?: emptyposition
-            "level", "amount" -> Skills.getTop(place)?.level?.toString() ?: emptyposition
+        return when (type) {
+            "name" -> Skills.getTop(place)?.player?.savedDisplayName ?: emptyPosition
+            "level", "amount" -> Skills.getTop(place)?.level?.toString() ?: emptyPosition
             else -> null
         }
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
@@ -166,7 +166,7 @@ class Skill(
             .replace("%required_xp%", player.getFormattedRequiredXP(skill))
             .replace("%description%", skill.getDescription(level))
             .replace("%skill%", skill.name)
-            .replace("%skill_leaderboard_rank%", skill.getPosition(player.uniqueId)?.toString() ?: plugin.langYml.getString("top.empty-position"))
+            .replace("%rank%", skill.getPosition(player.uniqueId)?.toString() ?: plugin.langYml.getString("top.empty-position"))
             .let { addPlaceholdersInto(it, level) }
             .injectRewardPlaceholders(level)
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
@@ -166,6 +166,7 @@ class Skill(
             .replace("%required_xp%", player.getFormattedRequiredXP(skill))
             .replace("%description%", skill.getDescription(level))
             .replace("%skill%", skill.name)
+            .replace("%skill_top_position%", skill.getPosition(player.uniqueId)?.toString() ?: plugin.langYml.getString("top.empty-position"))
             .let { addPlaceholdersInto(it, level) }
             .injectRewardPlaceholders(level)
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
@@ -166,7 +166,7 @@ class Skill(
             .replace("%required_xp%", player.getFormattedRequiredXP(skill))
             .replace("%description%", skill.getDescription(level))
             .replace("%skill%", skill.name)
-            .replace("%skill_top_position%", skill.getPosition(player.uniqueId)?.toString() ?: plugin.langYml.getString("top.empty-position"))
+            .replace("%skill_leaderboard_rank%", skill.getPosition(player.uniqueId)?.toString() ?: plugin.langYml.getString("top.empty-position"))
             .let { addPlaceholdersInto(it, level) }
             .injectRewardPlaceholders(level)
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skills.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skills.kt
@@ -44,7 +44,7 @@ object Skills : RegistrableCategory<Skill>("skill", "skills") {
     }
 
     fun registerPlaceholders(plugin: EcoSkillsPlugin) {
-        PlayerPlaceholder(plugin, "top_position") { player ->
+        PlayerPlaceholder(plugin, "leaderboard_rank") { player ->
             val emptyPosition = plugin.langYml.getString("top.empty-position")
             val position = getPosition(player.uniqueId)
             position?.toString() ?: emptyPosition

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skills.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skills.kt
@@ -9,6 +9,7 @@ import com.willfp.ecoskills.util.InvalidConfigurationException
 import com.willfp.ecoskills.util.LeaderboardEntry
 import com.willfp.libreforge.loader.LibreforgePlugin
 import com.willfp.libreforge.loader.configs.RegistrableCategory
+import com.willfp.eco.core.placeholder.PlayerPlaceholder
 import org.bukkit.Bukkit
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -34,6 +35,20 @@ object Skills : RegistrableCategory<Skill>("skill", "skills") {
             player,
             player.totalSkillLevel
         )
+    }
+
+    fun getPosition(uuid: UUID): Int? {
+        val leaderboard = leaderboardCache.get(true)
+        val index = leaderboard.indexOf(uuid)
+        return if (index == -1) null else index + 1
+    }
+
+    fun registerPlaceholders(plugin: EcoSkillsPlugin) {
+        PlayerPlaceholder(plugin, "top_position") { player ->
+            val emptyPosition = plugin.langYml.getString("top.empty-position")
+            val position = getPosition(player.uniqueId)
+            position?.toString() ?: emptyPosition
+        }.register()
     }
 
     override fun clear(plugin: LibreforgePlugin) {


### PR DESCRIPTION
Added new placeholder to return a player's leaderboard position %ecoskills_<id>_leaderboard_rank%
Improved regex for %ecoskills_top_...% placeholder for better inclusivity of IDs with underscores
Added new %rank% internal placeholder for config.yml to return player's skill rank