### PR TITLE
feat/aux_changes

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/EcoSkillsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/EcoSkillsPlugin.kt
@@ -123,6 +123,7 @@ class EcoSkillsPlugin : LibreforgePlugin() {
 
         TemporaryBossBarHandler.startTicking()
         MagicHandler.startTicking()
+        GainXPDisplay.startTickingSounds()
     }
 
     override fun loadPluginCommands(): List<PluginCommand> {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/Levellable.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/Levellable.kt
@@ -17,6 +17,7 @@ import com.willfp.eco.util.toNumeral
 import com.willfp.ecoskills.skills.SkillsLeaderboard.getPosition
 import com.willfp.ecoskills.util.LevelInjectable
 import com.willfp.ecoskills.util.loadDescriptionPlaceholders
+import jdk.internal.joptsimple.util.RegexMatcher.regex
 import org.bukkit.OfflinePlayer
 import java.util.concurrent.TimeUnit
 
@@ -82,6 +83,8 @@ abstract class Levellable(
             .replace("%ecoskills_${id}%", level.toString())
             .replace("%level%", level.toString())
             .replace("%level_numeral%", level.toNumeral())
+            .replace("%previous_level%", (level - 1).toString())
+            .replace("%previous_level_numeral%", (level - 1).toNumeral())
 
         // Regex for %level_X% and %level_X_numeral%
         val regex = Regex("%level_(-?\\d+)(_numeral)?%")

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/Skill.kt
@@ -269,6 +269,8 @@ class Skill(
                 ).apply {
                     addPlaceholder(NamedValue("level", level))
                     addPlaceholder(NamedValue("level_numeral", level.toNumeral()))
+                    addPlaceholder(NamedValue("previous_level", level - 1))
+                    addPlaceholder(NamedValue("previous_level_numeral", (level - 1).toNumeral()))
                 }
             )
         }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/GainXPDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/GainXPDisplay.kt
@@ -19,6 +19,7 @@ import com.willfp.ecoskills.api.getSkillProgress
 import com.willfp.ecoskills.api.getSkillXP
 import com.willfp.ecoskills.plugin
 import com.willfp.ecoskills.skills.Skill
+import org.bukkit.Bukkit
 import org.bukkit.boss.BarColor
 import org.bukkit.boss.BarStyle
 import org.bukkit.entity.Player
@@ -56,20 +57,33 @@ object GainXPDisplay : Listener {
 
     private val sound = PlayableSound.create(plugin.configYml.getSubsection("skills.gain-xp.sound"))
 
+    private val soundsToPlay = mutableSetOf<UUID>()
+
+    internal fun startTickingSounds() {
+        plugin.scheduler.runTimer(1, 1) {
+            for (uuid in soundsToPlay) {
+                val player = Bukkit.getPlayer(uuid) ?: continue
+                sound?.playTo(player)
+            }
+
+            soundsToPlay.clear()
+        }
+    }
+
     @EventHandler(priority = EventPriority.MONITOR)
     fun handle(event: PlayerSkillXPGainEvent) {
         val player = event.player
         val current = gainCache.get(playerSkill(player, event.skill)) { 0.0 }
         gainCache.put(playerSkill(player, event.skill), current + event.gainedXP)
 
+        if (player.isXPGainSoundEnabled) {
+            soundsToPlay += event.player.uniqueId
+        }
+
         // Run next tick because level up calls before xp is added
         plugin.scheduler.run {
             handleActionBar(event)
             handleBossBar(event)
-
-            if (player.isXPGainSoundEnabled) {
-                sound?.playTo(player)
-            }
         }
     }
 


### PR DESCRIPTION
- xp gain sounds now play a maximum of once per tick per player
- fixed %previous_level% and %previous_level_numeral% not working