### PR TITLE
fix: use stable UUIDs for stat modifier effects

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectAddStat.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectAddStat.kt
@@ -15,6 +15,7 @@ import com.willfp.libreforge.effects.Identifiers
 import com.willfp.libreforge.effects.RunOrder
 import com.willfp.libreforge.get
 import org.bukkit.entity.Player
+import java.util.UUID
 
 object EffectAddStat : Effect<NoCompileData>("add_stat") {
     override val runOrder = RunOrder.START
@@ -24,6 +25,9 @@ object EffectAddStat : Effect<NoCompileData>("add_stat") {
         require("amount", "You must specify the amount to add/remove!")
     }
 
+    // "${playerUUID}_${holderID}" -> set of modifier UUIDs active for that holder
+    private val activeModifiers = HashMap<String, MutableSet<UUID>>()
+
     override fun onEnable(
         dispatcher: Dispatcher<*>,
         config: Config,
@@ -32,12 +36,18 @@ object EffectAddStat : Effect<NoCompileData>("add_stat") {
         compileData: NoCompileData
     ) {
         val player = dispatcher.get<Player>() ?: return
-
         val stat = Stats.getByID(config.getString("stat")) ?: return
 
+        val lookupKey = "${player.uniqueId}_${holder.holder.id}"
+        val modifierUUID = UUID.nameUUIDFromBytes("${lookupKey}_${stat.id}".toByteArray())
+
+        activeModifiers.getOrPut(lookupKey) { mutableSetOf() }.add(modifierUUID)
+
+        // Remove before re-adding to avoid doubling on reload
+        player.removeStatModifier(modifierUUID)
         player.addStatModifier(
             StatModifier(
-                identifiers.uuid,
+                modifierUUID,
                 stat,
                 config.getDoubleFromExpression("amount", player),
                 ModifierOperation.ADD
@@ -48,6 +58,11 @@ object EffectAddStat : Effect<NoCompileData>("add_stat") {
     override fun onDisable(dispatcher: Dispatcher<*>, identifiers: Identifiers, holder: ProvidedHolder) {
         val player = dispatcher.get<Player>() ?: return
 
-        player.removeStatModifier(identifiers.uuid)
+        val lookupKey = "${player.uniqueId}_${holder.holder.id}"
+        val modifierUUIDs = activeModifiers.remove(lookupKey) ?: return
+
+        for (uuid in modifierUUIDs) {
+            player.removeStatModifier(uuid)
+        }
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectAddStat.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectAddStat.kt
@@ -25,7 +25,6 @@ object EffectAddStat : Effect<NoCompileData>("add_stat") {
         require("amount", "You must specify the amount to add/remove!")
     }
 
-    // "${playerUUID}_${holderID}" -> set of modifier UUIDs active for that holder
     private val activeModifiers = HashMap<String, MutableSet<UUID>>()
 
     override fun onEnable(
@@ -43,7 +42,6 @@ object EffectAddStat : Effect<NoCompileData>("add_stat") {
 
         activeModifiers.getOrPut(lookupKey) { mutableSetOf() }.add(modifierUUID)
 
-        // Remove before re-adding to avoid doubling on reload
         player.removeStatModifier(modifierUUID)
         player.addStatModifier(
             StatModifier(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectAddStatTemporarily.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectAddStatTemporarily.kt
@@ -1,7 +1,6 @@
 package com.willfp.ecoskills.libreforge
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.eco.util.randInt
 import com.willfp.ecoskills.api.addStatModifier
 import com.willfp.ecoskills.api.modifiers.ModifierOperation
 import com.willfp.ecoskills.api.modifiers.StatModifier
@@ -35,7 +34,7 @@ object EffectAddStatTemporarily : Effect<NoCompileData>("add_stat_temporarily") 
         val player = data.player ?: return false
         val stat = Stats.getByID(config.getString("stat")) ?: return false
         val amount = config.getDoubleFromExpression("amount", data)
-        val uuid = UUID.nameUUIDFromBytes("ast_${randInt(0, 1000000)}".toByteArray())
+        val uuid = UUID.randomUUID()
 
         player.addStatModifier(
             StatModifier(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyAllStats.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyAllStats.kt
@@ -15,6 +15,7 @@ import com.willfp.libreforge.effects.Identifiers
 import com.willfp.libreforge.effects.RunOrder
 import com.willfp.libreforge.get
 import org.bukkit.entity.Player
+import java.util.UUID
 
 object EffectMultiplyAllStats : Effect<NoCompileData>("multiply_all_stats") {
     override val runOrder = RunOrder.START
@@ -25,6 +26,9 @@ object EffectMultiplyAllStats : Effect<NoCompileData>("multiply_all_stats") {
 
     override val shouldReload = false
 
+    // "${playerUUID}_${holderID}" -> set of modifier UUIDs active for that holder
+    private val activeModifiers = HashMap<String, MutableSet<UUID>>()
+
     override fun onEnable(
         dispatcher: Dispatcher<*>,
         config: Config,
@@ -33,13 +37,16 @@ object EffectMultiplyAllStats : Effect<NoCompileData>("multiply_all_stats") {
         compileData: NoCompileData
     ) {
         val player = dispatcher.get<Player>() ?: return
+        val lookupKey = "${player.uniqueId}_${holder.holder.id}"
+        val uuids = activeModifiers.getOrPut(lookupKey) { mutableSetOf() }
 
-        val factory = identifiers.makeFactory()
-
-        for ((offset, stat) in Stats.values().withIndex()) {
+        for (stat in Stats.values()) {
+            val modifierUUID = UUID.nameUUIDFromBytes("${lookupKey}_${stat.id}".toByteArray())
+            uuids.add(modifierUUID)
+            player.removeStatModifier(modifierUUID)
             player.addStatModifier(
                 StatModifier(
-                    factory.makeIdentifiers(offset).uuid,
+                    modifierUUID,
                     stat,
                     config.getDoubleFromExpression("multiplier", player),
                     ModifierOperation.MULTIPLY
@@ -51,10 +58,11 @@ object EffectMultiplyAllStats : Effect<NoCompileData>("multiply_all_stats") {
     override fun onDisable(dispatcher: Dispatcher<*>, identifiers: Identifiers, holder: ProvidedHolder) {
         val player = dispatcher.get<Player>() ?: return
 
-        val factory = identifiers.makeFactory()
+        val lookupKey = "${player.uniqueId}_${holder.holder.id}"
+        val modifierUUIDs = activeModifiers.remove(lookupKey) ?: return
 
-        for (offset in Stats.values().indices) {
-            player.removeStatModifier(factory.makeIdentifiers(offset).uuid)
+        for (uuid in modifierUUIDs) {
+            player.removeStatModifier(uuid)
         }
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyAllStats.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyAllStats.kt
@@ -26,7 +26,6 @@ object EffectMultiplyAllStats : Effect<NoCompileData>("multiply_all_stats") {
 
     override val shouldReload = false
 
-    // "${playerUUID}_${holderID}" -> set of modifier UUIDs active for that holder
     private val activeModifiers = HashMap<String, MutableSet<UUID>>()
 
     override fun onEnable(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyStat.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyStat.kt
@@ -15,6 +15,7 @@ import com.willfp.libreforge.effects.Identifiers
 import com.willfp.libreforge.effects.RunOrder
 import com.willfp.libreforge.get
 import org.bukkit.entity.Player
+import java.util.UUID
 
 object EffectMultiplyStat : Effect<NoCompileData>("multiply_stat") {
     override val runOrder = RunOrder.START
@@ -26,6 +27,9 @@ object EffectMultiplyStat : Effect<NoCompileData>("multiply_stat") {
 
     override val shouldReload = false
 
+    // "${playerUUID}_${holderID}" -> set of modifier UUIDs active for that holder
+    private val activeModifiers = HashMap<String, MutableSet<UUID>>()
+
     override fun onEnable(
         dispatcher: Dispatcher<*>,
         config: Config,
@@ -36,9 +40,15 @@ object EffectMultiplyStat : Effect<NoCompileData>("multiply_stat") {
         val player = dispatcher.get<Player>() ?: return
         val stat = Stats.getByID(config.getString("stat")) ?: return
 
+        val lookupKey = "${player.uniqueId}_${holder.holder.id}"
+        val modifierUUID = UUID.nameUUIDFromBytes("${lookupKey}_${stat.id}".toByteArray())
+
+        activeModifiers.getOrPut(lookupKey) { mutableSetOf() }.add(modifierUUID)
+
+        player.removeStatModifier(modifierUUID)
         player.addStatModifier(
             StatModifier(
-                identifiers.uuid,
+                modifierUUID,
                 stat,
                 config.getDoubleFromExpression("multiplier", player),
                 ModifierOperation.MULTIPLY
@@ -49,6 +59,11 @@ object EffectMultiplyStat : Effect<NoCompileData>("multiply_stat") {
     override fun onDisable(dispatcher: Dispatcher<*>, identifiers: Identifiers, holder: ProvidedHolder) {
         val player = dispatcher.get<Player>() ?: return
 
-        player.removeStatModifier(identifiers.uuid)
+        val lookupKey = "${player.uniqueId}_${holder.holder.id}"
+        val modifierUUIDs = activeModifiers.remove(lookupKey) ?: return
+
+        for (uuid in modifierUUIDs) {
+            player.removeStatModifier(uuid)
+        }
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyStat.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyStat.kt
@@ -27,7 +27,6 @@ object EffectMultiplyStat : Effect<NoCompileData>("multiply_stat") {
 
     override val shouldReload = false
 
-    // "${playerUUID}_${holderID}" -> set of modifier UUIDs active for that holder
     private val activeModifiers = HashMap<String, MutableSet<UUID>>()
 
     override fun onEnable(

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyStatTemporarily.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/libreforge/EffectMultiplyStatTemporarily.kt
@@ -1,7 +1,6 @@
 package com.willfp.ecoskills.libreforge
 
 import com.willfp.eco.core.config.interfaces.Config
-import com.willfp.eco.util.randInt
 import com.willfp.ecoskills.api.addStatModifier
 import com.willfp.ecoskills.api.modifiers.ModifierOperation
 import com.willfp.ecoskills.api.modifiers.StatModifier
@@ -35,7 +34,7 @@ object EffectMultiplyStatTemporarily : Effect<NoCompileData>("multiply_stat_temp
         val player = data.player ?: return false
         val stat = Stats.getByID(config.getString("stat")) ?: return false
         val multiplier = config.getDoubleFromExpression("multiplier", data)
-        val uuid = UUID.nameUUIDFromBytes("mst_${randInt(0, 1000000)}".toByteArray())
+        val uuid = UUID.randomUUID()
 
         player.addStatModifier(
             StatModifier(


### PR DESCRIPTION
## Problem

All five stat modifier effects (`add_stat`, `multiply_stat`, `multiply_all_stats`, `add_stat_temporarily`, `multiply_stat_temporarily`) had bugs in how they tracked modifier UUIDs.

### Permanent effects (`add_stat`, `multiply_stat`, `multiply_all_stats`)

These use `onEnable`/`onDisable`. The libreforge `Effect` base class generates identifiers using a per-player counter:

- `enable()` increments the counter, then passes `makeIdentifiers(count)` to `onEnable`
- `disable()` reads the current counter value and passes `makeIdentifiers(count)` to `onDisable`, then decrements

The counter is shared across **all** activations of the same effect type for a given player. If two sources each apply `add_stat` (e.g. two skills at different levels), the UUID passed to `onDisable` depends on the **current** counter value, not the value used when that specific activation was enabled.

**Example with two active `add_stat` effects:**
1. Enable A → counter=1, modifier UUID = `makeUUID(1)` ✓
2. Enable B → counter=2, modifier UUID = `makeUUID(2)` ✓
3. Disable A (counter still 2) → removes `makeUUID(2)` ✗ (removes B's modifier)
4. Disable B (counter now 1) → removes `makeUUID(1)` ✗ (removes A's modifier)

The two effects silently swap each other's modifiers on removal.

### Temporary effects (`add_stat_temporarily`, `multiply_stat_temporarily`)

These used `UUID.nameUUIDFromBytes("prefix_${randInt(0, 1000000)}")`. `nameUUIDFromBytes` is deterministic — same input produces the same UUID. With only 1,000,000 possible values, two rapid triggers can collide: the second activation overwrites the first in the modifier map, and the first's scheduled removal then deletes the second's modifier — leaving the player with no modifier for the remainder of the second activation's duration.

## Fix

**Permanent effects:** replaced the counter-based identifier with a stable UUID derived from `UUID.nameUUIDFromBytes("${playerUUID}_${holderID}_${statID}")`, unique per (player, holder, stat) triple regardless of enable/disable ordering. An `activeModifiers` map tracks all UUIDs per holder so `onDisable` cleans them up correctly. A `removeStatModifier` before `addStatModifier` in `onEnable` prevents doubling on reload. This mirrors the approach already used in libreforge's own AuraSkills `EffectAddStat` integration.

**Temporary effects:** replaced `UUID.nameUUIDFromBytes(...)` with `UUID.randomUUID()`.