### PR TITLE
feat: level-up sounds now play once

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/EcoSkillsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/EcoSkillsPlugin.kt
@@ -124,6 +124,7 @@ class EcoSkillsPlugin : LibreforgePlugin() {
         TemporaryBossBarHandler.startTicking()
         MagicHandler.startTicking()
         GainXPDisplay.startTickingSounds()
+        LevelUpDisplay.startTickingSounds()
     }
 
     override fun loadPluginCommands(): List<PluginCommand> {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/LevelUpDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoskills/skills/display/LevelUpDisplay.kt
@@ -5,18 +5,35 @@ import com.willfp.eco.util.toComponent
 import com.willfp.ecoskills.api.event.PlayerSkillLevelUpEvent
 import com.willfp.ecoskills.plugin
 import net.kyori.adventure.title.Title
+import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import java.time.Duration
+import java.util.UUID
 
 object LevelUpDisplay : Listener {
     private val sound = PlayableSound.create(plugin.configYml.getSubsection("skills.level-up.sound"))
+
+    private val soundsToPlay = mutableSetOf<UUID>()
+
+    internal fun startTickingSounds() {
+        plugin.scheduler.runTimer(1, 1) {
+            for (uuid in soundsToPlay) {
+                val player = Bukkit.getPlayer(uuid) ?: continue
+                sound?.playTo(player)
+            }
+
+            soundsToPlay.clear()
+        }
+    }
 
     @EventHandler
     fun handle(event: PlayerSkillLevelUpEvent) {
         val player = event.player
         val skill = event.skill
         val level = event.level
+
+        soundsToPlay += player.uniqueId
 
         if (plugin.configYml.getBool("skills.level-up.message.enabled")) {
             val rawMessage = plugin.configYml.getStrings("skills.level-up.message.message")
@@ -52,7 +69,5 @@ object LevelUpDisplay : Listener {
                 )
             )
         }
-
-        sound?.playTo(player)
     }
 }


### PR DESCRIPTION
Levelling up multiple levels will now only play the sound once, similar to https://github.com/Auxilor/EcoSkills/pull/199 but for levels, not xp.