### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/ecoskills/how-to-make-a-skill.md
+++ b/documentation/ecoskills/how-to-make-a-skill.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make a Skill
 sidebar_position: 1
 ---
@@ -235,7 +235,7 @@ reward-messages:
 ```
 
 ### The Level Up Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the skill. You can configure effects, conditions, filters, and mutators in this section to run when the skill levels up.
 

--- a/documentation/ecoskills/how-to-make-an-effect.md
+++ b/documentation/ecoskills/how-to-make-an-effect.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make an Effect
 sidebar_position: 3
 ---
@@ -42,7 +42,7 @@ description: "&a%placeholder%%&8 chance to get $50 every time you mine a block" 
 ```
 
 ### The Effects Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the effect. You can configure effects, conditions, filters, and mutators in this section to run while this effect is levelled and active.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation (e.g. `:::dangerEffects Section` → `:::danger Effects Section`).